### PR TITLE
docs(readme): switch Quick Start to 'pip install aicertify' + add PyPI badges

### DIFF
--- a/README.hi-IN.md
+++ b/README.hi-IN.md
@@ -21,9 +21,10 @@
 </p>
 
 <p align="center">
+  <a href="https://pypi.org/project/aicertify/"><img src="https://img.shields.io/pypi/v/aicertify?style=flat-square&color=blue" alt="PyPI"></a>
+  <a href="https://pepy.tech/project/aicertify"><img src="https://img.shields.io/pepy/dt/aicertify?style=flat-square" alt="Downloads"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml"><img src="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/stargazers"><img src="https://img.shields.io/github/stars/Principled-Evolution/aicertify?style=flat-square" alt="Stars"></a>
-  <a href="https://github.com/Principled-Evolution/aicertify/releases"><img src="https://img.shields.io/badge/version-0.7.0-brightgreen.svg?style=flat-square" alt="Version 0.7.0"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.12%2B-blue.svg?style=flat-square" alt="Python 3.12+"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square" alt="Apache 2.0"></a>
   <a href="https://www.openpolicyagent.org/"><img src="https://img.shields.io/badge/built%20on-OPA-7D4698.svg?style=flat-square" alt="Built on OPA"></a>
@@ -47,13 +48,26 @@
 ## Quick Start
 
 ```bash
+pip install aicertify
+```
+
+बंडल्ड डेमो चलाने के लिए (सैंपल कॉन्ट्रैक्ट + examples के लिए रिपॉज़िटरी क्लोन करें):
+
+```bash
 git clone https://github.com/Principled-Evolution/aicertify.git
 cd aicertify
-pip install -e .
 python examples/quickstart.py
 ```
 
 यह क्विकस्टार्ट एक सैंपल AI एप्लिकेशन को EU AI Act पॉलिसी सेट के माध्यम से जोड़ता है और `reports/` में एक कंप्लायंस रिपोर्ट लिखता है। उसे खोलिए। यही आपके ऑडिट डिलिवरेबल का स्वरूप है — हाथ से नहीं, जनरेट होकर।
+
+### डेवलपमेंट के लिए
+
+```bash
+git clone https://github.com/Principled-Evolution/aicertify.git
+cd aicertify
+pip install -e .
+```
 
 ### न्यूनतम Python उपयोग
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -21,9 +21,10 @@
 </p>
 
 <p align="center">
+  <a href="https://pypi.org/project/aicertify/"><img src="https://img.shields.io/pypi/v/aicertify?style=flat-square&color=blue" alt="PyPI"></a>
+  <a href="https://pepy.tech/project/aicertify"><img src="https://img.shields.io/pepy/dt/aicertify?style=flat-square" alt="ダウンロード"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml"><img src="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/stargazers"><img src="https://img.shields.io/github/stars/Principled-Evolution/aicertify?style=flat-square" alt="Stars"></a>
-  <a href="https://github.com/Principled-Evolution/aicertify/releases"><img src="https://img.shields.io/badge/version-0.7.0-brightgreen.svg?style=flat-square" alt="Version 0.7.0"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.12%2B-blue.svg?style=flat-square" alt="Python 3.12+"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square" alt="Apache 2.0"></a>
   <a href="https://www.openpolicyagent.org/"><img src="https://img.shields.io/badge/built%20on-OPA-7D4698.svg?style=flat-square" alt="Built on OPA"></a>
@@ -47,13 +48,26 @@
 ## クイックスタート
 
 ```bash
+pip install aicertify
+```
+
+同梱のデモを実行するには(サンプル契約と examples 一式を取得するためにリポジトリをクローンします):
+
+```bash
 git clone https://github.com/Principled-Evolution/aicertify.git
 cd aicertify
-pip install -e .
 python examples/quickstart.py
 ```
 
 クイックスタートでは、サンプル AI アプリケーションを EU AI Act のポリシーセットに通し、コンプライアンスレポートを `reports/` に出力します。それを開いてみてください。手書きではなく、生成された監査成果物の実例です。
+
+### 開発用のセットアップ
+
+```bash
+git clone https://github.com/Principled-Evolution/aicertify.git
+cd aicertify
+pip install -e .
+```
 
 ### 最小限の Python での使い方
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -21,9 +21,10 @@
 </p>
 
 <p align="center">
+  <a href="https://pypi.org/project/aicertify/"><img src="https://img.shields.io/pypi/v/aicertify?style=flat-square&color=blue" alt="PyPI"></a>
+  <a href="https://pepy.tech/project/aicertify"><img src="https://img.shields.io/pepy/dt/aicertify?style=flat-square" alt="다운로드"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml"><img src="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/stargazers"><img src="https://img.shields.io/github/stars/Principled-Evolution/aicertify?style=flat-square" alt="Stars"></a>
-  <a href="https://github.com/Principled-Evolution/aicertify/releases"><img src="https://img.shields.io/badge/version-0.7.0-brightgreen.svg?style=flat-square" alt="Version 0.7.0"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.12%2B-blue.svg?style=flat-square" alt="Python 3.12+"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square" alt="Apache 2.0"></a>
   <a href="https://www.openpolicyagent.org/"><img src="https://img.shields.io/badge/built%20on-OPA-7D4698.svg?style=flat-square" alt="Built on OPA"></a>
@@ -47,13 +48,26 @@
 ## 빠른 시작
 
 ```bash
+pip install aicertify
+```
+
+샘플 계약과 예시를 함께 실행하려면 저장소를 클론하세요:
+
+```bash
 git clone https://github.com/Principled-Evolution/aicertify.git
 cd aicertify
-pip install -e .
 python examples/quickstart.py
 ```
 
 빠른 시작 스크립트는 샘플 AI 애플리케이션을 EU AI Act 정책 세트에 통과시키고 컴플라이언스 리포트를 `reports/`에 작성합니다. 파일을 열어 보세요. 이것이 바로 여러분의 감사 산출물의 모습입니다 — 손으로 작성하지 않고 생성된 리포트입니다.
+
+### 개발용 설치
+
+```bash
+git clone https://github.com/Principled-Evolution/aicertify.git
+cd aicertify
+pip install -e .
+```
 
 ### 최소 Python 사용 예시
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@
 </p>
 
 <p align="center">
+  <a href="https://pypi.org/project/aicertify/"><img src="https://img.shields.io/pypi/v/aicertify?style=flat-square&color=blue" alt="PyPI"></a>
+  <a href="https://pepy.tech/project/aicertify"><img src="https://img.shields.io/pepy/dt/aicertify?style=flat-square" alt="Downloads"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml"><img src="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/stargazers"><img src="https://img.shields.io/github/stars/Principled-Evolution/aicertify?style=flat-square" alt="Stars"></a>
-  <a href="https://github.com/Principled-Evolution/aicertify/releases"><img src="https://img.shields.io/badge/version-0.7.0-brightgreen.svg?style=flat-square" alt="Version 0.7.0"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.12%2B-blue.svg?style=flat-square" alt="Python 3.12+"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square" alt="Apache 2.0"></a>
   <a href="https://www.openpolicyagent.org/"><img src="https://img.shields.io/badge/built%20on-OPA-7D4698.svg?style=flat-square" alt="Built on OPA"></a>
@@ -59,13 +60,26 @@ AICertify is part of the [Open Policy Agent ecosystem](https://www.openpolicyage
 ## Quick Start
 
 ```bash
+pip install aicertify
+```
+
+To run the canonical demo (clone the repo for the sample contract + examples):
+
+```bash
 git clone https://github.com/Principled-Evolution/aicertify.git
 cd aicertify
-pip install -e .
 python examples/quickstart.py
 ```
 
 The quickstart wires a sample AI application through the EU AI Act policy set and writes a compliance report into `reports/`. Open it. That's what your audit deliverable looks like — generated, not handwritten.
+
+### For development
+
+```bash
+git clone https://github.com/Principled-Evolution/aicertify.git
+cd aicertify
+pip install -e .
+```
 
 ### Minimal Python usage
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,9 +21,10 @@
 </p>
 
 <p align="center">
+  <a href="https://pypi.org/project/aicertify/"><img src="https://img.shields.io/pypi/v/aicertify?style=flat-square&color=blue" alt="PyPI"></a>
+  <a href="https://pepy.tech/project/aicertify"><img src="https://img.shields.io/pepy/dt/aicertify?style=flat-square" alt="下载量"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml"><img src="https://github.com/Principled-Evolution/aicertify/actions/workflows/aicertify-ci.yaml/badge.svg" alt="持续集成"></a>
   <a href="https://github.com/Principled-Evolution/aicertify/stargazers"><img src="https://img.shields.io/github/stars/Principled-Evolution/aicertify?style=flat-square" alt="Star 数"></a>
-  <a href="https://github.com/Principled-Evolution/aicertify/releases"><img src="https://img.shields.io/badge/version-0.7.0-brightgreen.svg?style=flat-square" alt="版本 0.7.0"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.12%2B-blue.svg?style=flat-square" alt="Python 3.12+"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square" alt="Apache 2.0 许可证"></a>
   <a href="https://www.openpolicyagent.org/"><img src="https://img.shields.io/badge/built%20on-OPA-7D4698.svg?style=flat-square" alt="基于 OPA 构建"></a>
@@ -47,13 +48,26 @@
 ## 快速开始
 
 ```bash
+pip install aicertify
+```
+
+运行内置演示(克隆仓库以获取示例合约和示例代码):
+
+```bash
 git clone https://github.com/Principled-Evolution/aicertify.git
 cd aicertify
-pip install -e .
 python examples/quickstart.py
 ```
 
 quickstart 会将一个示例 AI 应用接入 EU AI Act 策略集,并将合规报告写入 `reports/`。打开看看 —— 这就是您的审计交付物的样貌:由系统生成,而非手工撰写。
+
+### 用于开发
+
+```bash
+git clone https://github.com/Principled-Evolution/aicertify.git
+cd aicertify
+pip install -e .
+```
 
 ### 最简 Python 用法
 


### PR DESCRIPTION
v0.7.0 is now live on PyPI: <https://pypi.org/project/aicertify/0.7.0/>.

This PR updates **all five READMEs** (English + zh-CN + ja-JP + ko-KR + hi-IN) so the first install instruction is the single line everyone expects:

```bash
pip install aicertify
```

## Changes

### Badge row
- ➕ PyPI version badge — auto-updates on every release
- ➕ Downloads badge (pepy.tech total)
- ➖ Hard-coded "Version 0.7.0" badge (now redundant)

### Quick Start
- Headline install is now `pip install aicertify`
- Git-clone path demoted to "running the bundled demo" (still useful for `examples/quickstart.py`)
- New "For development" / "開発用のセットアップ" / "개발용 설치" / "डेवलपमेंट के लिए" / "用于开发" subsection retains the `pip install -e .` editable-install path for contributors

Translations all use locale-appropriate prose for the new sub-section headings ("用于开发" / "開発用のセットアップ" / "개발용 설치" / "डेवलपमेंट के लिए"). Diagrams, language switcher, comparison table, and every other section are untouched.

## Verified

- PyPI listing live with full metadata: 16 keywords, classifiers, all 6 project URLs (Homepage, Repository, Documentation, Issues, Changelog, Policy Library (gopal))
- Both wheel + sdist uploaded
- Local wheel install from PyPI succeeds; `aicertify --help` works; `from aicertify import regulations, application` works