### PR TITLE
docs(readme): tighten top-fold — remove H1 and bold tagline

### DIFF
--- a/README.hi-IN.md
+++ b/README.hi-IN.md
@@ -5,18 +5,12 @@
   </picture>
 </div>
 
-<h1 align="center">AICertify</h1>
-
 <p align="center">
   <a href="README.md">English</a> |
   <a href="README.zh-CN.md">简体中文</a> |
   <a href="README.ja-JP.md">日本語</a> |
   <a href="README.ko-KR.md">한국어</a> |
   <strong>हिन्दी</strong>
-</p>
-
-<p align="center">
-  <strong>AI सिस्टम्स के लिए Compliance-as-code।</strong>
 </p>
 
 <p align="center">

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -5,18 +5,12 @@
   </picture>
 </div>
 
-<h1 align="center">AICertify</h1>
-
 <p align="center">
   <a href="README.md">English</a> |
   <a href="README.zh-CN.md">简体中文</a> |
   <strong>日本語</strong> |
   <a href="README.ko-KR.md">한국어</a> |
   <a href="README.hi-IN.md">हिन्दी</a>
-</p>
-
-<p align="center">
-  <strong>AI システムのためのコンプライアンス・アズ・コード。</strong>
 </p>
 
 <p align="center">

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -5,18 +5,12 @@
   </picture>
 </div>
 
-<h1 align="center">AICertify</h1>
-
 <p align="center">
   <a href="README.md">English</a> |
   <a href="README.zh-CN.md">简体中文</a> |
   <a href="README.ja-JP.md">日本語</a> |
   <strong>한국어</strong> |
   <a href="README.hi-IN.md">हिन्दी</a>
-</p>
-
-<p align="center">
-  <strong>AI 시스템을 위한 컴플라이언스 코드화(compliance-as-code).</strong>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -5,18 +5,12 @@
   </picture>
 </div>
 
-<h1 align="center">AICertify</h1>
-
 <p align="center">
   <a href="README.md">English</a> |
   <a href="README.zh-CN.md">简体中文</a> |
   <a href="README.ja-JP.md">日本語</a> |
   <a href="README.ko-KR.md">한국어</a> |
   <a href="README.hi-IN.md">हिन्दी</a>
-</p>
-
-<p align="center">
-  <strong>Compliance-as-code for AI systems.</strong>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,18 +5,12 @@
   </picture>
 </div>
 
-<h1 align="center">AICertify</h1>
-
 <p align="center">
   <a href="README.md">English</a> |
   <strong>简体中文</strong> |
   <a href="README.ja-JP.md">日本語</a> |
   <a href="README.ko-KR.md">한국어</a> |
   <a href="README.hi-IN.md">हिन्दी</a>
-</p>
-
-<p align="center">
-  <strong>面向 AI 系统的合规即代码。</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Follow-up to PR #61. The new hero banner SVG already contains the wordmark "AICertify" and the tagline "Compliance-as-code for AI systems" baked in. Keeping the separate `<h1>` and the bold tagline paragraph below it duplicated content and pushed the substantive copy down.

After this change the top sequence is:

> hero banner → language switcher → one-sentence positioning line (italic) → badges → hero diagram

Applied uniformly to all 5 READMEs (en + zh-CN + ja-JP + ko-KR + hi-IN). Each language's localized positioning sentence is preserved.

Accessibility check: the banner SVG carries `<title>AICertify</title>` plus an alt attribute, so screen readers still get the project name. GitHub's own repo-name heading sits above the README content regardless of what's in the README.

## Test plan

- [x] Verified rendered top-fold across all 5 language variants on the local working tree
- [ ] Manual: review rendered READMEs in **GitHub light and dark theme** post-merge