### PR TITLE
release: AICertify v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] — 2026-05-14
+
 ### Changed
 
 - **`aicertify demo` rewritten for the canonical rich-UX flow.** The previous demo runner produced plain `print()` output; it now mirrors [`examples/quickstart.py`](examples/quickstart.py) exactly — uses the high-level `application.create()` + `app.evaluate()` API and wraps each step in `print_banner`, `spinner`, `MessageGroup`, and `success` markers from `aicertify.utils.logging_config`. Visually identical to the canonical SDK experience.

--- a/aicertify/__init__.py
+++ b/aicertify/__init__.py
@@ -6,7 +6,7 @@ compliance frameworks.
 """
 
 # Version information
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 # Direct imports for developer convenience
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aicertify"
-version = "0.7.1"
+version = "0.7.2"
 description = "Compliance-as-code for AI systems. Audit your AI against the EU AI Act, NIST AI RMF, and 13+ regulatory frameworks using Open Policy Agent (OPA) — and produce audit-ready PDF, Markdown, JSON, or HTML reports."
 authors = [
     {name = "Kapil Madan", email = "kapil.madan@gmail.com"},


### PR DESCRIPTION
## Summary

Cuts a release tag for the demo rich-UX rewrite (PR #64) and the supporting fixes shipped since v0.7.1. No code changes here — just the version bump and CHANGELOG migration.

- \`pyproject.toml\` + \`aicertify/__init__.py\` → 0.7.2
- CHANGELOG: \`[Unreleased]\` → \`[0.7.2] — 2026-05-14\`

After merge: tag \`v0.7.2\` and upload wheel + sdist to PyPI.